### PR TITLE
fix #1324

### DIFF
--- a/vod/hls/m3u8_builder.c
+++ b/vod/hls/m3u8_builder.c
@@ -926,8 +926,7 @@ m3u8_builder_ext_x_media_tags_write(
 		}
 
 		label = &tracks[media_type]->media_info.label;
-		if (label->len == 0 ||
-			(media_type == MEDIA_TYPE_AUDIO && !adaptation_sets->multi_audio))
+		if (label->len == 0)
 		{
 			label = &default_label;
 		}
@@ -938,7 +937,7 @@ m3u8_builder_ext_x_media_tags_write(
 			group_index,
 			label);
 
-		if (media_type != MEDIA_TYPE_AUDIO || adaptation_sets->multi_audio)
+		if (media_type != MEDIA_TYPE_AUDIO || tracks[media_type]->media_info.language != VOD_LANG_UND)
 		{
 			p = vod_sprintf(p, M3U8_EXT_MEDIA_LANG,
 				lang_get_rfc_5646_name(tracks[media_type]->media_info.language));


### PR DESCRIPTION
Always output language and label information for audio tracks even when there is a single track

```
curl http://localhost:8080/preview/963775/it/master.m3u8
#EXTM3U

#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="audio0",NAME="Deutsch",LANGUAGE="de",AUTOSELECT=YES,DEFAULT=YES,CHANNELS="2",URI="index-f1-a1.m3u8"

```

media_info->label is set by default to language native name in ngx_http_vod_parse_lang_param

Works only with         `vod_hls_force_unmuxed_segments     on;`
