### PR TITLE
fix: hls subtitle frame never duplicated

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/nginx-vod-module.iml" filepath="$PROJECT_DIR$/.idea/nginx-vod-module.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/nginx-vod-module.iml
+++ b/.idea/nginx-vod-module.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="CPP_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/vod/hds/hds_amf0_encoder.c
+++ b/vod/hds/hds_amf0_encoder.c
@@ -127,7 +127,6 @@ hds_amf0_write_metadata(u_char* p, media_set_t* media_set, media_track_t** track
 	uint64_t duration;
 	uint32_t timescale;
 	uint32_t count;
-	uint32_t bitrate = 0;
 	uint8_t sound_format;
 
 	count = AMF0_COMMON_FIELDS_COUNT;
@@ -155,7 +154,6 @@ hds_amf0_write_metadata(u_char* p, media_set_t* media_set, media_track_t** track
 	if (tracks[MEDIA_TYPE_VIDEO] != NULL)
 	{
 		media_info = &tracks[MEDIA_TYPE_VIDEO]->media_info;
-		bitrate += media_info->bitrate;
 		p = hds_amf0_append_array_number_value(p, &amf0_width, media_info->u.video.width);
 		p = hds_amf0_append_array_number_value(p, &amf0_height, media_info->u.video.height);
 		p = hds_amf0_append_array_number_value(p, &amf0_videodatarate, (double)media_info->bitrate / 1000.0);
@@ -166,7 +164,6 @@ hds_amf0_write_metadata(u_char* p, media_set_t* media_set, media_track_t** track
 	if (tracks[MEDIA_TYPE_AUDIO] != NULL)
 	{
 		media_info = &tracks[MEDIA_TYPE_AUDIO]->media_info;
-		bitrate += media_info->bitrate;
 		p = hds_amf0_append_array_number_value(p, &amf0_audiodatarate, (double)media_info->bitrate / 1000.0);
 		p = hds_amf0_append_array_number_value(p, &amf0_audiosamplerate, media_info->u.audio.sample_rate);
 		p = hds_amf0_append_array_number_value(p, &amf0_audiosamplesize, media_info->u.audio.bits_per_sample);

--- a/vod/subtitle/webvtt_builder.c
+++ b/vod/subtitle/webvtt_builder.c
@@ -30,9 +30,9 @@ webvtt_builder_build(
 	media_track_t* first_track = media_set->filtered_tracks;
 	input_frame_t* cur_frame;
 	input_frame_t* last_frame;
-    uint64_t start_time;
-    uint64_t segment_start_time = media_set->segment_start_time;
-    //uint64_t segment_end_time = media_set->segment_start_time + media_set->segment_duration;
+	uint64_t start_time;
+	uint64_t segment_start_time = media_set->segment_start_time;
+	//uint64_t segment_end_time = media_set->segment_start_time + media_set->segment_duration;
 	uint32_t id_size;
 	size_t result_size;
 	u_char* end;
@@ -87,25 +87,25 @@ webvtt_builder_build(
 				last_frame = part->last_frame;
 			}
 
-            if (start_time >= segment_start_time) {
-                src = (u_char * )(uintptr_t)
-                cur_frame->offset;
+			if (start_time >= segment_start_time) {
+				src = (u_char * )(uintptr_t)
+				cur_frame->offset;
 
-                // cue identifier
-                id_size = cur_frame->key_frame;
-                p = vod_copy(p, src, id_size);
-                src += id_size;
+				// cue identifier
+				id_size = cur_frame->key_frame;
+				p = vod_copy(p, src, id_size);
+				src += id_size;
 
-                // cue timings
-                p = webvtt_builder_write_timestamp(p, start_time);
-                p = vod_copy(p, WEBVTT_TIMESTAMP_DELIM, sizeof(WEBVTT_TIMESTAMP_DELIM) - 1);
-                p = webvtt_builder_write_timestamp(p, start_time + cur_frame->pts_delay);
+				// cue timings
+				p = webvtt_builder_write_timestamp(p, start_time);
+				p = vod_copy(p, WEBVTT_TIMESTAMP_DELIM, sizeof(WEBVTT_TIMESTAMP_DELIM) - 1);
+				p = webvtt_builder_write_timestamp(p, start_time + cur_frame->pts_delay);
 
-                // cue settings list + cue payload
-                p = vod_copy(p, src, cur_frame->size - id_size);
-            }
+				// cue settings list + cue payload
+				p = vod_copy(p, src, cur_frame->size - id_size);
+			}
 
-            start_time += cur_frame->duration;
+			start_time += cur_frame->duration;
 		}
 	}
 

--- a/vod/subtitle/webvtt_builder.c
+++ b/vod/subtitle/webvtt_builder.c
@@ -32,7 +32,7 @@ webvtt_builder_build(
 	input_frame_t* last_frame;
     uint64_t start_time;
     uint64_t segment_start_time = media_set->segment_start_time;
-    uint64_t segment_end_time = media_set->segment_start_time + media_set->segment_duration;
+    //uint64_t segment_end_time = media_set->segment_start_time + media_set->segment_duration;
 	uint32_t id_size;
 	size_t result_size;
 	u_char* end;
@@ -87,30 +87,25 @@ webvtt_builder_build(
 				last_frame = part->last_frame;
 			}
 
-			src = (u_char*)(uintptr_t)cur_frame->offset;
+            if (start_time >= segment_start_time) {
+                src = (u_char * )(uintptr_t)
+                cur_frame->offset;
 
-			// cue identifier
-			id_size = cur_frame->key_frame;
-			p = vod_copy(p, src, id_size);
-			src += id_size;
+                // cue identifier
+                id_size = cur_frame->key_frame;
+                p = vod_copy(p, src, id_size);
+                src += id_size;
 
+                // cue timings
+                p = webvtt_builder_write_timestamp(p, start_time);
+                p = vod_copy(p, WEBVTT_TIMESTAMP_DELIM, sizeof(WEBVTT_TIMESTAMP_DELIM) - 1);
+                p = webvtt_builder_write_timestamp(p, start_time + cur_frame->pts_delay);
 
-            uint64_t vtt_start_time = start_time;
-            if (start_time < segment_start_time) {
-                vtt_start_time = segment_start_time;
+                // cue settings list + cue payload
+                p = vod_copy(p, src, cur_frame->size - id_size);
             }
-            uint64_t vtt_end_time = start_time + cur_frame->pts_delay;
-            if (vtt_end_time > segment_end_time) {
-                vtt_end_time = segment_end_time;
-            }
-			// cue timings
-			p = webvtt_builder_write_timestamp(p, vtt_start_time);
-			p = vod_copy(p, WEBVTT_TIMESTAMP_DELIM, sizeof(WEBVTT_TIMESTAMP_DELIM) - 1);
-			p = webvtt_builder_write_timestamp(p, vtt_end_time);
-			start_time += cur_frame->duration;
 
-			// cue settings list + cue payload
-			p = vod_copy(p, src, cur_frame->size - id_size);
+            start_time += cur_frame->duration;
 		}
 	}
 

--- a/vod/subtitle/webvtt_builder.c
+++ b/vod/subtitle/webvtt_builder.c
@@ -30,7 +30,9 @@ webvtt_builder_build(
 	media_track_t* first_track = media_set->filtered_tracks;
 	input_frame_t* cur_frame;
 	input_frame_t* last_frame;
-	uint64_t start_time;
+    uint64_t start_time;
+    uint64_t segment_start_time = media_set->segment_start_time;
+    uint64_t segment_end_time = media_set->segment_start_time + media_set->segment_duration;
 	uint32_t id_size;
 	size_t result_size;
 	u_char* end;
@@ -92,10 +94,19 @@ webvtt_builder_build(
 			p = vod_copy(p, src, id_size);
 			src += id_size;
 
+
+            uint64_t vtt_start_time = start_time;
+            if (start_time < segment_start_time) {
+                vtt_start_time = segment_start_time;
+            }
+            uint64_t vtt_end_time = start_time + cur_frame->pts_delay;
+            if (vtt_end_time > segment_end_time) {
+                vtt_end_time = segment_end_time;
+            }
 			// cue timings
-			p = webvtt_builder_write_timestamp(p, start_time);
+			p = webvtt_builder_write_timestamp(p, vtt_start_time);
 			p = vod_copy(p, WEBVTT_TIMESTAMP_DELIM, sizeof(WEBVTT_TIMESTAMP_DELIM) - 1);
-			p = webvtt_builder_write_timestamp(p, start_time + cur_frame->pts_delay);
+			p = webvtt_builder_write_timestamp(p, vtt_end_time);
 			start_time += cur_frame->duration;
 
 			// cue settings list + cue payload


### PR DESCRIPTION
Chromecast shakaplayer does not de-duplicate cues in HLS. 

This fixes it by only outputing cues that start during the segment.

From my understanding (and some testing), the subtitles will not disappear early on segment change in normal playback if they are not duplicated in all segments. The only ill effect I can think of is that the cue will not appear on seek in some cases. But this is not a common use case, so a much less visible impact than duplicated segments.

For example with 8s segments, segment 2 will be from 00:08:00  to 00:16:00

### Before:
**s-1-f7.vtt**
```
WEBVTT

1
00:00:00.120 --> 00:00:4.120
Dies ist ein Text auf Türkisch

2
00:00:07.320 --> 00:00:09.920
* Roter Hintergrund *
```
**s-2-f7.vtt**
```
WEBVTT

2
00:00:07.320 --> 00:00:09.920
* Roter Hintergrund *

3
00:00:10.120 --> 00:00:12.120
Dies ist ein Text auf Türkisch
```
### After:
**s-1-f7.vtt**
```
WEBVTT

1
00:00:00.120 --> 00:00:4.120
Dies ist ein Text auf Türkisch

2
00:00:07.320 --> 00:00:09.920
* Roter Hintergrund *
```
**s-2-f7.vtt**
```
WEBVTT

3
00:00:10.120 --> 00:00:12.120
Dies ist ein Text auf Türkisch
```